### PR TITLE
Fix startTimer method to prevent timer from running under zero

### DIFF
--- a/Activity.js
+++ b/Activity.js
@@ -16,16 +16,16 @@ class Activity {
       logActivity.classList.toggle("hidden");
     }
     function timer() {
-      sec--;
-      if (sec < 0) {
+      if (sec > 0) {
+        sec--;
+      }
+      if (sec < 0 && min >= 0) {
          min--
          sec = 59;
       } else {
-        if (min === 0 && sec === 0) {
           clearInterval(counterSec);
           setTimeout(updateButton, 1000);
           this.completed = true;
-        }
       }
       timeRemaining.innerText = `${(min < 10 ? "0" : "") + min}:${(sec < 10 ? "0" : "") + sec}`
     }


### PR DESCRIPTION
## Is this a fix or a feature?
+ Fix

## What is the change?
+ Changes two conditions in startTimer:
   + sec and min variables can only decrement if their values are greater than zero.

## What does it fix?
+ Prevents timer from decrementing to a value less than zero if the Minutes field is given a value of zero.

## Where should the reviewer start?
+ Activity.js - lines 19 and 22, nested in the timer helper function.

## How should this be tested?
+ Run the timer on the create-activity layout and ensure only non-negative numbers are displayed.